### PR TITLE
tableの設定変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
         // terminalとpostgresを繋げる
         $ docker-compose exec postgres bash
 
-        // postgresにlogin
-        $ psql -U admin
+        // postgresにlogin test dbに移動
+        $ psql -U admin test
     ### init.sql等を更新した時にすること
         // dockerを落とす
         $ docker-compose down -v

--- a/go/repository/user.go
+++ b/go/repository/user.go
@@ -28,7 +28,7 @@ func NewUser() IUser {
 func (r *User) ByIDs(ids []int64) (*model.Users, error) {
 	m := &model.Users{}
 	if len(ids) != 0 {
-		_, err := r.session.Select("*").From("Users").Where("id IN ?", ids).Load(m)
+		_, err := r.session.Select("*").From("users").Where("id IN ?", ids).Load(m)
 		if err != nil {
 			return nil, fmt.Errorf("fetch error :%v", err)
 		}

--- a/go/repository/weight.go
+++ b/go/repository/weight.go
@@ -26,7 +26,7 @@ func NewWeight() IWeight {
 
 func (r *Weight) ByUserID(id int64) (*model.Weights, error) {
 	m := &model.Weights{}
-	_, err := r.session.Select("*").From("Weights").Where("user_id = ?", id).Load(m)
+	_, err := r.session.Select("*").From("weights").Where("user_id = ?", id).Load(m)
 	if err != nil {
 		return nil, fmt.Errorf("fetch error :%v", err)
 	}

--- a/postgres/init/init.sql
+++ b/postgres/init/init.sql
@@ -2,8 +2,8 @@ CREATE DATABASE test;
 
 \c test
 
-CREATE TABLE Users (
-    ID SERIAL NOT NULL,
+CREATE TABLE users (
+    ID SERIAL,
     Name VARCHAR(200),
     Height REAL,
     Weight REAL,
@@ -13,11 +13,11 @@ CREATE TABLE Users (
     PRIMARY KEY (ID)
 );
 
-INSERT INTO Users(ID, Name, Height, Weight, Sex, Old) VALUES (1, 'Aizu Taro', 164.2, 58.8, 0, 21),
-    (2, 'Aizu Hanako', 164.2, 58.8, 0, 21);
+INSERT INTO users(Name, Height, Weight, Sex, Old) VALUES ('Aizu Taro', 164.2, 58.8, 0, 21),
+    ('Aizu Hanako', 164.2, 58.8, 0, 21);
 
-CREATE TABLE Weights (
-    ID SERIAL NOT NULL,
+CREATE TABLE weights (
+    ID SERIAL,
     User_ID SERIAL NOT NULL,
     Value REAL,
     Created_at timestamp NOT NULL default current_timestamp,
@@ -25,6 +25,6 @@ CREATE TABLE Weights (
     CONSTRAINT fk_Users FOREIGN KEY(User_ID) REFERENCES Users(ID) ON DELETE CASCADE
 );
 
-INSERT INTO Weights(ID, User_ID, Value) VALUES (1, 1, 78.2),
-    (2, 2, 58.8),
-    (3, 2, 45.8);
+INSERT INTO Weights(User_ID, Value) VALUES (1, 78.2),
+    (2, 58.8),
+    (2, 45.8);


### PR DESCRIPTION
## table名をキャメル型に修正

今まで先頭大文字でtableを作っていたがpostgresが裏でよしなにキャメル型に変換してくれていた。しかしpostをする際に先頭大文字でinsert使用とするとtable is not existとerrorが返ってきてしまう為正しい書式に修正。

## tableの設定変更&初期Insert変更

- idをauto incrementに
- auto increment時明示的にIDを指定してのInsertはだめ🙅‍♂️(auto incrementに指定したcol用のtableが存在していてそこに入っているcurrent valueをもとにauto increment が勝手に指定してくれるため。もし明示的に指定してしまうとcurrent valueを反映しないためずれが生じてしまう。)
- tablename_colname_seqという名前のtableがauto incrementのcurrent valueを保持している。