### PR TITLE
db リファクタリング

### DIFF
--- a/postgres/init/init.sql
+++ b/postgres/init/init.sql
@@ -3,28 +3,28 @@ CREATE DATABASE test;
 \c test
 
 CREATE TABLE users (
-    ID SERIAL,
-    Name VARCHAR(200),
-    Height REAL,
-    Weight REAL,
-    Sex INTEGER,
-    Old INTEGER,
-    Created_at timestamp NOT NULL default current_timestamp,
-    PRIMARY KEY (ID)
+    id SERIAL,
+    name VARCHAR(200),
+    height REAL,
+    weight REAL,
+    sex INTEGER,
+    old INTEGER,
+    created_at timestamp NOT NULL default current_timestamp,
+    PRIMARY KEY (id)
 );
 
-INSERT INTO users(Name, Height, Weight, Sex, Old) VALUES ('Aizu Taro', 164.2, 58.8, 0, 21),
+INSERT INTO users(name, height, weight, sex, old) VALUES ('Aizu Taro', 164.2, 58.8, 0, 21),
     ('Aizu Hanako', 164.2, 58.8, 0, 21);
 
 CREATE TABLE weights (
-    ID SERIAL,
-    User_ID SERIAL NOT NULL,
-    Value REAL,
-    Created_at timestamp NOT NULL default current_timestamp,
-    PRIMARY KEY (ID),
-    CONSTRAINT fk_Users FOREIGN KEY(User_ID) REFERENCES Users(ID) ON DELETE CASCADE
+    id SERIAL,
+    user_id SERIAL NOT NULL,
+    value REAL,
+    created_at timestamp NOT NULL default current_timestamp,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_Users FOREIGN KEY(user_id) REFERENCES Users(id) ON DELETE CASCADE
 );
 
-INSERT INTO Weights(User_ID, Value) VALUES (1, 78.2),
+INSERT INTO weights(user_id, value) VALUES (1, 78.2),
     (2, 58.8),
     (2, 45.8);


### PR DESCRIPTION
## 目的
db col nameも全て小文字に統一
back modelはあくまでgoないで使うものなのでよしなに大文字でも大丈夫🙆‍♂️(goでわかりやすいように意図的に先頭大文字にしてる)

## 背景
postgres内部でよしなにcol name, table name全部小文字にしてくれてるらしいので`init.sql`でも小文字に統一