### PR TITLE
user post apiの修正

### DIFF
--- a/go/form/user.go
+++ b/go/form/user.go
@@ -12,6 +12,7 @@ type (
 		Weight float32 `json:"weight" valid:"required~user weight を入力してください"`
 		Sex    int64   `json:"sex" valid:"required~user sex を入力してください"`
 		Old    int64   `json:"old" valid:"required~user old を入力してください"`
+		Pass   string  `json:"pass" valid:"required~user pass を入力してください"`
 	}
 )
 

--- a/go/model/user.go
+++ b/go/model/user.go
@@ -4,7 +4,6 @@ type User struct {
 	ID     int64
 	Name   string
 	Height float32
-	Weight float32
 	Sex    int64
 	Old    int64
 }
@@ -14,7 +13,7 @@ type Users []User
 type CreateUser struct {
 	Name   string
 	Height float32
-	Weight float32
 	Sex    int64
 	Old    int64
+	Pass   string
 }

--- a/go/repository/user.go
+++ b/go/repository/user.go
@@ -11,6 +11,7 @@ import (
 type (
 	IUser interface {
 		ByIDs(ids []int64) (*model.Users, error)
+		GetIDByNamePass(name, pass string) (*int64, error)
 		Create(m *model.CreateUser) error
 	}
 
@@ -34,16 +35,38 @@ func (r *User) ByIDs(ids []int64) (*model.Users, error) {
 		}
 		return m, nil
 	}
-	_, err := r.session.Select("*").From("Users").Load(m)
+	_, err := r.session.Select("*").From("users").Load(m)
 	if err != nil {
 		return nil, fmt.Errorf("fetch error :%v", err)
 	}
 	return m, nil
 }
 
+func (r *User) GetIDByNamePass(name, pass string) (*int64, error) {
+	user := &model.User{}
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if len(pass) == 0 {
+		return nil, fmt.Errorf("pass is required")
+	}
+	ret, err := r.session.Select("*").From("users").
+		Where("name = ?", name).
+		Where("pass = ?", pass).
+		Load(user)
+	if err != nil {
+		return nil, fmt.Errorf("fetch error :%v", err)
+	}
+	if ret == 0 {
+		return nil, fmt.Errorf("couldn't find user by name: %v, pass: %v", name, pass)
+	}
+
+	return &(*user).ID, nil
+}
+
 func (r *User) Create(m *model.CreateUser) error {
 	_, err := r.session.InsertInto("users").
-		Columns("name", "height", "weight", "sex", "old").
+		Columns("name", "height", "sex", "old", "pass").
 		Record(m).
 		Exec()
 	if err != nil {

--- a/go/response/user.go
+++ b/go/response/user.go
@@ -7,7 +7,6 @@ type (
 		ID     int64   `json:"id"`
 		Name   string  `json:"name"`
 		Height float32 `json:"height"`
-		Weight float32 `json:"weight"`
 		Sex    int64   `json:"sex"`
 		Old    int64   `json:"old"`
 	}
@@ -21,12 +20,11 @@ func NewUser(m *model.User) *User {
 	}
 
 	return &User{
-		ID:      m.ID,
-		Name:    m.Name,
-		Height:  m.Height,
-		Weight:  m.Weight,
-		Sex:     m.Sex,
-		Old:     m.Old,
+		ID:     m.ID,
+		Name:   m.Name,
+		Height: m.Height,
+		Sex:    m.Sex,
+		Old:    m.Old,
 	}
 }
 

--- a/postgres/init/init.sql
+++ b/postgres/init/init.sql
@@ -6,15 +6,16 @@ CREATE TABLE users (
     id SERIAL,
     name VARCHAR(200),
     height REAL,
-    weight REAL,
     sex INTEGER,
     old INTEGER,
+    pass VARCHAR(200),
+    state INTEGER DEFAULT 0,
     created_at timestamp NOT NULL default current_timestamp,
     PRIMARY KEY (id)
 );
 
-INSERT INTO users(name, height, weight, sex, old) VALUES ('Aizu Taro', 164.2, 58.8, 0, 21),
-    ('Aizu Hanako', 164.2, 58.8, 0, 21);
+INSERT INTO users(name, height, sex, old, pass) VALUES ('Aizu Taro', 164.2, 0, 21, 'test'),
+    ('Aizu Hanako', 164.2, 0, 21, 'test');
 
 CREATE TABLE weights (
     id SERIAL,


### PR DESCRIPTION
## 目的
user post apiを叩いた時にweights tableにweightが追加されるように修正
初期weightがweight tableに追加されない件

## 修正点
- users tableからweight colの削除
- POST /users を叩いた時にweight tableに初期weightが追加されるように編集

## 疑問点
ロジックをserviceで集約するかhandlerで集約するか正味迷ったけどserviceで集約することにした。理由としてはhandlerで集約した場合特に意味のないmethodがserviceに生えることになってあまり綺麗じゃないかなって思ったから。
上記解決策としてはweight serviceのCreateをgenerics化して`weight: float32`をもつinterfaceを許容するように編集すればhandlerでロジックの集約できた。
なんかgenerics化する時に他のinterfaceの命名速も見直さないといけない説出てきてそれは労力かかりすぎるからやめた🥺
